### PR TITLE
Allow "Empty" Environment Git Commit

### DIFF
--- a/lib/git_manager.rb
+++ b/lib/git_manager.rb
@@ -40,7 +40,7 @@ class GitManager
     end
 
     cmd = "git -C #{framework_path} add #{store_in} ;
-           git -C #{framework_path} commit -m '#{commit_msg}' > /dev/null 2>&1"
+           git -C #{framework_path} commit --allow-empty -m '#{commit_msg}' > /dev/null 2>&1"
 
     if Helper.execute(cmd)
       Status.reset_status


### PR DESCRIPTION
BSF must allow an empty environment git commit if the current executed iteration does not have any differences from the previous one.

This is needed in order to track ALL iterations.